### PR TITLE
Add runtime locale registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,28 @@ Then in components use as:
 locale translations: The component needs more locale translations. You can `Open an issue to write the locale translations, or submit a pull request`.
 See example [here](https://github.com/runkids/vue2-timeago/blob/master/src/helpers/lang).
 
+### Custom locale
+
+You can register new locales at runtime without editing library files.
+
+```javascript
+import Vue from 'vue'
+import Vue2Timeago, { addLocale } from 'vue2-timeago'
+
+addLocale('pirate', {
+  short: { now: 'arr', sec: 's', min: 'm', hour: 'h', day: 'd' },
+  long: {
+    now: 'arr',
+    sec: (n) => `${n} second${n > 1 ? 's' : ''} arr`,
+    min: (n) => `${n} minute${n > 1 ? 's' : ''} arr`,
+    hour: (n) => `${n} hour${n > 1 ? 's' : ''} arr`,
+    day: (n) => `${n} day${n > 1 ? 's' : ''} arr`,
+  },
+})
+
+Vue.use(Vue2Timeago)
+```
+
 locale support list :
 
 - English ( en )

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import TimeAgo from './TimeAgo.vue'
+import { addLocale } from '../helpers/lang'
 
 const components = {
   TimeAgo,
@@ -27,4 +28,4 @@ if (GlobalVue) {
 }
 
 export default components
-export { TimeAgo }
+export { TimeAgo, addLocale }

--- a/src/helpers/lang/index.js
+++ b/src/helpers/lang/index.js
@@ -23,7 +23,7 @@ import vi from './countries/vi'
 import zh_CN from './countries/zh_CN'
 import zh_TW from './countries/zh_TW'
 
-export default {
+const locales = {
   zh_TW,
   zh_CN,
   en,
@@ -49,3 +49,9 @@ export default {
   da, // Danish
   vi, // Vietnam
 }
+
+export function addLocale(name, locale) {
+  locales[name] = locale
+}
+
+export default locales


### PR DESCRIPTION
## Summary
- allow dynamic locale registration with `addLocale`
- expose `addLocale` from plugin
- document runtime locale registration in README

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffce208cc832394bb51de077d5c92